### PR TITLE
Feature/layout options

### DIFF
--- a/lib/objects/_layout.scss
+++ b/lib/objects/_layout.scss
@@ -105,9 +105,9 @@ $supple-breakpoint-has-layout-fill: () !default;
 
 
 /**
- * Modifier: justify all layout cells
+ * Modifier: align all layout cells with space between
  */
-.o-layout--align-justify {
+.o-layout--align-apart {
   justify-content: space-between;
 }
 

--- a/lib/objects/_layout.scss
+++ b/lib/objects/_layout.scss
@@ -105,6 +105,14 @@ $supple-breakpoint-has-layout-fill: () !default;
 
 
 /**
+ * Modifier: justify all layout cells
+ */
+.o-layout--align-justify {
+  justify-content: space-between;
+}
+
+
+/**
  * Modifier: middle-align layout cells
  */
 .o-layout--align-middle {


### PR DESCRIPTION
Our local frontend developers noticed we really miss the option to use `justify: space-between`. Though we would be able to create the same result with some extra empty `div`s, we prefer to keep our code as clean as possible.

Houdoe!