### PR TITLE
Modified text modifier to support ch unit

### DIFF
--- a/lib/objects/_retain.scss
+++ b/lib/objects/_retain.scss
@@ -7,6 +7,7 @@
     ========================================================================= */
 
 $supple-retain-text-size: 40em !default;
+$supple-retain-text-size-chars: 70ch !default;
 $supple-retain-space: $supple-space !default;
 
 
@@ -41,10 +42,29 @@ $supple-retain-sizes: (
 
 
 /**
+ * Modifier: left
+ */
+.o-retain--left {
+  margin-left: 0;
+}
+
+
+/**
+ * Modifier: right
+ */
+.o-retain--right {
+  margin-right: 0;
+}
+
+
+/**
  * Modifier: text
  */
 .o-retain--text {
   --o-retain-max-width: #{$supple-retain-text-size};
+  @supports(max-width: $supple-retain-text-size-chars) {
+    max-width: $supple-retain-text-size-chars;
+  }
   padding-right: 0;
   padding-left: 0;
   margin-left: 0;


### PR DESCRIPTION
Added left and right retain modifier and modified text modifier to use ch units if supported by the browser.

While `u-margin-left-none` or `u-margin-left-none` could be used instead of the left and right modifiers, the modifiers seem to be just a little clearer when using retain in your code but are completely optional.

The text modifier however did not have an option to use characters as a maximum width, I assume this is because the ch unit is not supported by _some browsers_. `@supports` was added to the text modifier to use ch units if supported by the browser, or the original em units if not.