### PR TITLE
Feature/supple space base

### DIFF
--- a/lib/generic/_reset.scss
+++ b/lib/generic/_reset.scss
@@ -58,7 +58,7 @@ fieldset,
 figure,
 pre,
 hr {
-  @include supple-rem(margin, 0 0 $supple-space);
+  @include supple-rem(margin, 0 0 $supple-space-base);
 }
 
 
@@ -68,7 +68,7 @@ hr {
 ul,
 ol,
 dd {
-  @include supple-rem(margin-left, $supple-space);
+  @include supple-rem(margin-left, $supple-space-base);
 }
 
 /**

--- a/lib/objects/_flexembed.scss
+++ b/lib/objects/_flexembed.scss
@@ -10,7 +10,7 @@
 /**
  * Spacing
  */
-$supple-flexembed-space: $supple-space !default;
+$supple-flexembed-space: $supple-space-base !default;
 
 
 /**

--- a/lib/objects/_layout.scss
+++ b/lib/objects/_layout.scss
@@ -9,7 +9,7 @@
 /**
  * The default gutter
  */
-$supple-layout-gutter: $supple-space !default;
+$supple-layout-gutter: $supple-space-base !default;
 $supple-layout-gutter-tiny: $supple-space-tiny !default;
 $supple-layout-gutter-small: $supple-space-small !default;
 $supple-layout-gutter-large: $supple-space-large !default;

--- a/lib/objects/_layout.scss
+++ b/lib/objects/_layout.scss
@@ -9,11 +9,16 @@
 /**
  * The default gutter
  */
-$supple-layout-gutter: $supple-space-base !default;
+$supple-layout-gutter-base: $supple-space-base !default;
 $supple-layout-gutter-tiny: $supple-space-tiny !default;
 $supple-layout-gutter-small: $supple-space-small !default;
 $supple-layout-gutter-large: $supple-space-large !default;
 $supple-layout-gutter-huge: $supple-space-huge !default;
+
+/**
+ * Deprecated gutter variables
+ */
+ $supple-layout-gutter: $supple-layout-gutter-base !important;
 
 
 /**
@@ -162,8 +167,9 @@ $supple-breakpoint-has-layout-fill: () !default;
 
 /**
  * Modifier: Gutter
+ * - Deprecated gutter class: o-layout--gutter
  */
-.o-layout--gutter {
+.o-layout--gutter-base, .o-layout--gutter {
   @include supple-rem(margin-left, -$supple-layout-gutter);
 
   > .o-layout__cell {
@@ -216,7 +222,6 @@ $supple-breakpoint-has-layout-fill: () !default;
     @include supple-rem(padding-left, $supple-layout-gutter-huge);
   }
 }
-
 
 
 /*  Layout cell

--- a/lib/objects/_retain.scss
+++ b/lib/objects/_retain.scss
@@ -7,7 +7,6 @@
     ========================================================================= */
 
 $supple-retain-text-size: 40em !default;
-$supple-retain-text-size-chars: 70ch !default;
 $supple-retain-space: $supple-space-base !default;
 
 
@@ -42,29 +41,10 @@ $supple-retain-sizes: (
 
 
 /**
- * Modifier: left
- */
-.o-retain--left {
-  margin-left: 0;
-}
-
-
-/**
- * Modifier: right
- */
-.o-retain--right {
-  margin-right: 0;
-}
-
-
-/**
  * Modifier: text
  */
 .o-retain--text {
   --o-retain-max-width: #{$supple-retain-text-size};
-  @supports(max-width: $supple-retain-text-size-chars) {
-    max-width: $supple-retain-text-size-chars;
-  }
   padding-right: 0;
   padding-left: 0;
   margin-left: 0;

--- a/lib/objects/_retain.scss
+++ b/lib/objects/_retain.scss
@@ -7,6 +7,7 @@
     ========================================================================= */
 
 $supple-retain-text-size: 40em !default;
+$supple-retain-text-size-chars: 70ch !default;
 $supple-retain-space: $supple-space !default;
 
 
@@ -41,10 +42,29 @@ $supple-retain-sizes: (
 
 
 /**
+ * Modifier: left
+ */
+.o-retain--left {
+  margin-left: 0;
+}
+
+
+/**
+ * Modifier: right
+ */
+.o-retain--right {
+  margin-right: 0;
+}
+
+
+/**
  * Modifier: text
  */
 .o-retain--text {
   --o-retain-max-width: #{$supple-retain-text-size};
+  @supports(max-width: $supple-retain-text-size-chars) {
+    max-width: $supple-retain-text-size-chars;
+  }
   padding-right: 0;
   padding-left: 0;
   margin-left: 0;

--- a/lib/objects/_retain.scss
+++ b/lib/objects/_retain.scss
@@ -8,7 +8,7 @@
 
 $supple-retain-text-size: 40em !default;
 $supple-retain-text-size-chars: 70ch !default;
-$supple-retain-space: $supple-space !default;
+$supple-retain-space: $supple-space-base !default;
 
 
 /**

--- a/lib/settings/_defaults.scss
+++ b/lib/settings/_defaults.scss
@@ -39,7 +39,7 @@ $supple-space-factor-huge: 12 !default; // 96px
  * It is not recommended that you modify these following variables because it
  * can break your vertical rhythm. But if you want, you can :).
  */
-$supple-space: $supple-baseline * $supple-space-factor !default;
+$supple-space-base: $supple-baseline * $supple-space-factor !default;
 $supple-space-tiny: $supple-baseline * $supple-space-factor-tiny !default;
 $supple-space-small: $supple-baseline * $supple-space-factor-small !default;
 $supple-space-large: $supple-baseline * $supple-space-factor-large !default;
@@ -57,7 +57,7 @@ $supple-static-breakpoint: 1280px !default;
     ========================================================================= */
 
 $supple-font-size: 16px !default;
-$supple-line-height: $supple-space !default;
+$supple-line-height: $supple-space-base !default;
 $supple-line-height-ratio: $supple-line-height/$supple-font-size !default;
 
 

--- a/lib/settings/_defaults.scss
+++ b/lib/settings/_defaults.scss
@@ -27,11 +27,16 @@ $supple-baseline: 8px !default;
  * How many lines should our spacing units span?
  * Each value should be an unitless integer.
  */
-$supple-space-factor: 3 !default; // 24px
+$supple-space-factor-base: 3 !default; // 24px
 $supple-space-factor-tiny: 1 !default; // 8px
 $supple-space-factor-small: 2 !default; // 16px
 $supple-space-factor-large: 6 !default; // 48px
 $supple-space-factor-huge: 12 !default; // 96px
+
+/**
+ * Deprecated spacing factor variables
+ */
+ $supple-space-factor: $supple-space-factor-base !important;
 
 
 /**
@@ -39,11 +44,16 @@ $supple-space-factor-huge: 12 !default; // 96px
  * It is not recommended that you modify these following variables because it
  * can break your vertical rhythm. But if you want, you can :).
  */
-$supple-space-base: $supple-baseline * $supple-space-factor !default;
+$supple-space-base: $supple-baseline * $supple-space-factor-base !default;
 $supple-space-tiny: $supple-baseline * $supple-space-factor-tiny !default;
 $supple-space-small: $supple-baseline * $supple-space-factor-small !default;
 $supple-space-large: $supple-baseline * $supple-space-factor-large !default;
 $supple-space-huge: $supple-baseline * $supple-space-factor-huge !default;
+
+/**
+ * Deprecated spacing variables
+ */
+ $supple-space: $supple-space-base !important;
 
 
 /**
@@ -112,7 +122,7 @@ $supple-responsive-warning: 'You haven’t included `Sass MQ` and `settings/resp
 /**
  * Check that the chosen size factors are unitless, integer numbers.
  */
-@each $_supple-spacing-unit in $supple-space-factor $supple-space-factor-tiny $supple-space-factor-small $supple-space-factor-large $supple-space-factor-huge {
+@each $_supple-spacing-unit in $supple-space-factor-base $supple-space-factor-tiny $supple-space-factor-small $supple-space-factor-large $supple-space-factor-huge {
   @if (type-of($_supple-spacing-unit) == number) {
     @if (unitless($_supple-spacing-unit) == false) {
       @error '`#{$_supple-spacing-unit}` needs to be unitless.';

--- a/lib/utilities/_spacing.scss
+++ b/lib/utilities/_spacing.scss
@@ -34,6 +34,7 @@ $supple-spacing-directions: (
  * `key` is the classname, `value` is the value (duh!)
  */
 $supple-spacing-sizes: (
+  null: $supple-space-base,
   '-base': $supple-space-base,
   '-tiny': $supple-space-tiny,
   '-small': $supple-space-small,

--- a/lib/utilities/_spacing.scss
+++ b/lib/utilities/_spacing.scss
@@ -34,7 +34,7 @@ $supple-spacing-directions: (
  * `key` is the classname, `value` is the value (duh!)
  */
 $supple-spacing-sizes: (
-  null: $supple-space,
+  '-base': $supple-space-base,
   '-tiny': $supple-space-tiny,
   '-small': $supple-space-small,
   '-large': $supple-space-large,


### PR DESCRIPTION
To make the framework more userfriendly `$supple-space` is replaced with `$supple-space-base`.

Pros:
- Searching and replacing variables is easier
- Searching and replacing variables is uberhaupt possible
- pLEASE we just want to be able to search and replace our variables 😭